### PR TITLE
[codex] Add automation loop marketplace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Loop marketplace changes require maintainer review when code owner
+# review is enabled in branch protection.
+/_loops/ @subramanya1997
+/awesome-loops/ @subramanya1997
+/_layouts/loop.html @subramanya1997
+/assets/css/pages/loop-marketplace.css @subramanya1997
+/assets/js/pages/loop-marketplace.js @subramanya1997

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+
+## Loop Marketplace Checklist
+
+- [ ] New or changed loop listings live in `_loops/`.
+- [ ] Every loop has a title, short description, and usable prompt or instructions.
+- [ ] Optional source, attribution, MCP/resource links, and verification fields are accurate when provided.
+- [ ] The loop does not require secrets, credentials, private data, or unapproved destructive actions.
+- [ ] Agent export formats still make sense for Claude, Codex, and Cursor.
+
+## Validation
+
+- [ ] `ruby scripts/validate_content.rb`
+- [ ] `bundle exec jekyll build`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+## Automation Loops
+
+Automation-loop submissions are Markdown files in `_loops/`. Use the form at `/awesome-loops/automation/` or open a pull request that adds one file to `_loops/`.
+
+Every loop needs a title, a short description, and the actual prompt or operating instructions an agent can run. Source links, attribution, category, trigger, cadence, tooling, proof, memory, stop condition, tags, and MCP/resource links are optional.
+
+Submissions are reviewed before merge. Maintainers may edit titles, safety language, attribution, optional metadata, or export wording before approving. Do not include secrets, private customer data, credentialed URLs, or instructions that perform destructive actions without an explicit review step.
+
+Run these checks before requesting review:
+
+```bash
+ruby scripts/validate_content.rb
+bundle exec jekyll build
+```
+
+GitHub code-owner review is enforced only when repository branch protection requires it, so keep branch protection enabled for `main` before treating approvals as mandatory.

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,19 @@ permalink: pretty
 collections:
   books:
     output: true
+  loops:
+    output: true
+    permalink: /awesome-loops/automation/:path/
+
+defaults:
+  - scope:
+      path: ""
+      type: loops
+    values:
+      page_stylesheets:
+        - /assets/css/pages/loop-marketplace.css
+      page_scripts:
+        - /assets/js/pages/loop-marketplace.js
 
 highlighter: rouge
 kramdown:

--- a/_layouts/loop.html
+++ b/_layouts/loop.html
@@ -1,0 +1,153 @@
+---
+layout: default
+---
+{% assign loop_export_slug = page.slug | default: page.title | slugify %}
+<article class="loop-detail">
+  <nav class="loop-breadcrumbs" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="{{ '/' | prepend: site.baseurl }}" data-preserve-lang>Home</a></li>
+      <li><a href="{{ '/awesome-loops/automation/' | prepend: site.baseurl }}" data-preserve-lang>Loops</a></li>
+      <li aria-current="page">{{ page.title }}</li>
+    </ol>
+  </nav>
+
+  <header class="loop-detail-header">
+    {% if page.category or page.status %}
+      <p class="loop-eyebrow">
+        {% if page.category %}{{ page.category }}{% endif %}
+        {% if page.category and page.status %} / {% endif %}
+        {% if page.status %}{{ page.status }}{% endif %}
+      </p>
+    {% endif %}
+    <h1>{{ page.title }}</h1>
+    <p>{{ page.excerpt }}</p>
+  </header>
+
+  {% if page.category or page.trigger or page.cadence or page.tooling or page.proof or page.stop or page.memory %}
+    <section class="loop-detail-grid" aria-label="Optional loop details">
+      {% if page.category %}
+        <div>
+          <span>Category</span>
+          <strong>{{ page.category }}</strong>
+        </div>
+      {% endif %}
+      {% if page.trigger %}
+        <div>
+          <span>Trigger</span>
+          <strong>{{ page.trigger }}</strong>
+        </div>
+      {% endif %}
+      {% if page.cadence %}
+        <div>
+          <span>Cadence</span>
+          <strong>{{ page.cadence }}</strong>
+        </div>
+      {% endif %}
+      {% if page.tooling %}
+        <div>
+          <span>Tooling</span>
+          <strong>{{ page.tooling }}</strong>
+        </div>
+      {% endif %}
+      {% if page.proof %}
+        <div>
+          <span>Proof</span>
+          <strong>{{ page.proof }}</strong>
+        </div>
+      {% endif %}
+      {% if page.stop %}
+        <div>
+          <span>Stop</span>
+          <strong>{{ page.stop }}</strong>
+        </div>
+      {% endif %}
+      {% if page.memory %}
+        <div>
+          <span>Memory</span>
+          <strong>{{ page.memory }}</strong>
+        </div>
+      {% endif %}
+    </section>
+  {% endif %}
+
+  {% if page.source_url or page.source_title or page.attribution or page.links %}
+    <section class="loop-source-strip" aria-label="Links and attribution">
+      {% if page.source_url or page.source_title %}
+        <span>Source</span>
+        {% if page.source_url %}
+          <a href="{{ page.source_url }}" rel="noopener noreferrer">{{ page.source_title | default: page.source_url }}</a>
+        {% else %}
+          <strong>{{ page.source_title }}</strong>
+        {% endif %}
+      {% endif %}
+      {% if page.attribution %}
+        <span>Attribution</span>
+        <strong>{{ page.attribution }}</strong>
+      {% endif %}
+      {% if page.links %}
+        <span>Links</span>
+        <div class="loop-resource-links">
+          {% for link in page.links %}
+            <a href="{{ link.url }}" rel="noopener noreferrer">{{ link.title | default: link.url }}</a>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </section>
+  {% endif %}
+
+  <section class="loop-export-panel" aria-label="Use this loop">
+    <div>
+      <p class="loop-eyebrow">Use this loop</p>
+      <h2>Export for your agent</h2>
+      <p>Open the loop as a reviewable prompt in Claude or Cursor, copy it into Codex or Cursor project instructions, or download a standards-shaped Agent Skill.</p>
+      <ul class="loop-export-hints">
+        <li>Skills install as <code>SKILL.md</code> inside <code>.agents/skills/{{ loop_export_slug }}/</code>, <code>.claude/skills/{{ loop_export_slug }}/</code>, or <code>.cursor/skills/{{ loop_export_slug }}/</code>.</li>
+        <li>Cursor rules install as <code>.cursor/rules/{{ loop_export_slug }}.mdc</code>.</li>
+        <li>Deep links open a local review step; they do not run the loop automatically.</li>
+      </ul>
+    </div>
+    <div class="loop-export-actions">
+      <button type="button" data-loop-export="prompt">Copy prompt</button>
+      <button type="button" data-loop-open="claude">Try in Claude</button>
+      <button type="button" data-loop-open="cursor-prompt">Try in Cursor</button>
+      <button type="button" data-loop-open="cursor-rule">Add Cursor rule</button>
+      <button type="button" data-loop-export="skill">Copy Skill.md</button>
+      <button type="button" data-loop-export="agents">Copy AGENTS.md block</button>
+      <button type="button" data-loop-export="cursor">Copy Cursor rule</button>
+      <button type="button" data-loop-download="skill">Download Skill.md</button>
+      <button type="button" data-loop-download="cursor">Download .mdc</button>
+    </div>
+    <p class="loop-export-status" id="loop-export-status" aria-live="polite"></p>
+  </section>
+
+  <script type="application/json" id="loop-export-data">
+    {
+      "slug": {{ loop_export_slug | jsonify }},
+      "title": {{ page.title | jsonify }},
+      "excerpt": {{ page.excerpt | jsonify }},
+      "category": {{ page.category | jsonify }},
+      "trigger": {{ page.trigger | jsonify }},
+      "cadence": {{ page.cadence | jsonify }},
+      "tooling": {{ page.tooling | jsonify }},
+      "proof": {{ page.proof | jsonify }},
+      "stop": {{ page.stop | jsonify }},
+      "memory": {{ page.memory | jsonify }},
+      "sourceTitle": {{ page.source_title | jsonify }},
+      "sourceUrl": {{ page.source_url | jsonify }},
+      "attribution": {{ page.attribution | jsonify }},
+      "tags": {{ page.tags | jsonify }},
+      "links": {{ page.links | jsonify }},
+      "instructions": {{ page.content | strip | jsonify }}
+    }
+  </script>
+
+  <div class="post">
+    <article class="post-content loop-body">
+      {{ content }}
+    </article>
+  </div>
+
+  <footer class="loop-detail-footer">
+    <a href="https://github.com/subramanya1997/subramanya1997.github.io/edit/main/{{ page.path }}" rel="noopener noreferrer">Suggest an edit</a>
+  </footer>
+</article>

--- a/_loops/adversarial-review-loop.md
+++ b/_loops/adversarial-review-loop.md
@@ -1,0 +1,32 @@
+---
+layout: loop
+title: "Adversarial review loop"
+excerpt: "Use a fresh context to review a diff against the original requirements, then fix only correctness gaps."
+category: "Engineering"
+trigger: "A feature, migration, or bug fix is ready for review"
+cadence: "Before merge"
+tooling: "Git diff, subagent or second session, tests"
+proof: "Findings cite concrete gaps against the requirements"
+stop: "No correctness or requirement gaps remain"
+memory: "Record accepted findings and rejected non-issues in the PR"
+source_title: "Claude Code best practices"
+source_url: "https://code.claude.com/docs/en/best-practices"
+attribution: "Anthropic"
+status: curated
+tags:
+  - code-review
+  - verification
+  - pull-request
+---
+
+## Loop
+
+Run an independent review after the implementation session finishes.
+
+1. Give the reviewer the plan, acceptance criteria, and diff.
+2. Ask for gaps that affect correctness, coverage, security, or stated requirements.
+3. Ignore style-only suggestions unless they block the requirements.
+4. Fix accepted findings in the implementation session.
+5. Re-run the same tests and review once more.
+
+End only when the reviewer has no remaining requirement-level findings and the evidence is attached to the PR.

--- a/_loops/chief-of-staff-inbox-triage.md
+++ b/_loops/chief-of-staff-inbox-triage.md
@@ -1,0 +1,34 @@
+---
+layout: loop
+title: "Chief of staff inbox triage"
+excerpt: "Recurring inbox and Slack scan that identifies unanswered work, researches context, and drafts replies without sending."
+category: "Operations"
+trigger: "New Slack or email messages may need a response"
+cadence: "Every 30 minutes during work hours"
+tooling: "Slack, Gmail, calendar, browser, memory notes"
+proof: "Draft replies include source context and priority"
+stop: "All actionable messages are drafted, deferred, or marked no-action"
+memory: "Update a daily inbox log with open loops and decisions"
+source_title: "Codex-maxxing"
+source_url: "https://jxnl.co/writing/2026/05/10/codex-maxxing/"
+attribution: "Jason Liu"
+status: curated
+tags:
+  - inbox
+  - slack
+  - gmail
+  - operations
+---
+
+## Loop
+
+Check the active communication surfaces on a schedule.
+
+1. Scan recent Slack mentions, direct messages, and unread email.
+2. Identify messages that require a decision, response, research, or scheduling action.
+3. Pull the relevant context from calendar, docs, prior messages, and project notes.
+4. Draft replies, but do not send them.
+5. Rank items by urgency and consequence.
+6. Update the work log with what is waiting on the user.
+
+Stop when every new message has a draft, a clear no-action reason, or a recorded follow-up owner.

--- a/_loops/explore-plan-code-pr-loop.md
+++ b/_loops/explore-plan-code-pr-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Explore, plan, code, PR loop"
+excerpt: "Separate codebase exploration from implementation, then verify the change and open a reviewable PR."
+category: "Engineering"
+trigger: "A change touches multiple files or unfamiliar code"
+cadence: "Per feature or meaningful bug fix"
+tooling: "Repo search, tests, build, GitHub"
+proof: "Plan is reflected in the diff and checks pass"
+stop: "PR is open with evidence and no known failing checks"
+memory: "Keep the plan and verification notes in the PR description"
+source_title: "Claude Code best practices"
+source_url: "https://code.claude.com/docs/en/best-practices"
+attribution: "Anthropic"
+status: curated
+tags:
+  - planning
+  - pull-request
+  - tests
+---
+
+## Loop
+
+Use this when implementation risk comes from not understanding the existing system.
+
+1. Explore the relevant files, commands, docs, and tests without editing.
+2. Write a concrete plan that names files, data flow, risks, and verification.
+3. Implement the plan in the smallest coherent changes.
+4. Run the planned verification.
+5. Fix failures and update the plan if reality changed.
+6. Open a PR with the plan, diff summary, and verification evidence.
+
+Stop when the PR reviewer can understand what changed and how it was proven.

--- a/_loops/fan-out-migration-loop.md
+++ b/_loops/fan-out-migration-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Fan-out migration loop"
+excerpt: "Generate a file list, test the migration prompt on a small sample, then run the same constrained task across many files."
+category: "Engineering"
+trigger: "A repeated migration spans many files"
+cadence: "Per migration batch"
+tooling: "Task list, isolated sessions, scoped permissions, test suite"
+proof: "Representative samples pass before broad execution"
+stop: "Every target file is migrated or explicitly marked failed"
+memory: "Write an audit table of OK, skipped, and failed files"
+source_title: "Claude Code best practices"
+source_url: "https://code.claude.com/docs/en/best-practices"
+attribution: "Anthropic"
+status: curated
+tags:
+  - migration
+  - parallel
+  - batching
+---
+
+## Loop
+
+Use this when the same transformation can be applied independently to many files.
+
+1. Produce the complete target file list.
+2. Run the migration manually on two or three representative files.
+3. Refine the prompt and allowed tools until the sample produces clean diffs.
+4. Execute the migration across the full list in isolated sessions or batches.
+5. Collect structured OK, skipped, and failed results.
+6. Run the full project verification after batches are integrated.
+
+Stop when each target file has a recorded outcome and the integrated checks pass.

--- a/_loops/feedback-to-render-loop.md
+++ b/_loops/feedback-to-render-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Feedback to render loop"
+excerpt: "Monitor a feedback thread, revise the artifact when comments arrive, re-render, and post the new version for review."
+category: "Operations"
+trigger: "A reviewer comments on a shared artifact"
+cadence: "Every 15 minutes until approved"
+tooling: "Slack, renderer, browser or computer control, file upload"
+proof: "New artifact version addresses the latest feedback"
+stop: "Reviewer approves or no new feedback remains"
+memory: "Track feedback, version links, and unresolved decisions"
+source_title: "Codex-maxxing"
+source_url: "https://jxnl.co/writing/2026/05/10/codex-maxxing/"
+attribution: "Jason Liu"
+status: curated
+tags:
+  - feedback
+  - rendering
+  - slack
+---
+
+## Loop
+
+Keep artifact review moving after the first handoff.
+
+1. Watch the review thread at the selected cadence.
+2. Summarize each new comment into a change request or question.
+3. Apply changes to the source artifact.
+4. Re-render or regenerate the output.
+5. Upload the new version and tag the reviewer.
+6. Record which comments were handled.
+
+Stop when reviewers approve, no actionable feedback remains, or a human decision is needed.

--- a/_loops/full-product-evaluation-loop.md
+++ b/_loops/full-product-evaluation-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Full product evaluation loop"
+excerpt: "Define realistic scenarios for every major capability, fix failures, and rerun the whole evaluation set."
+category: "Evaluation"
+trigger: "A product or agent flow needs release confidence"
+cadence: "Before release or after major workflow changes"
+tooling: "Scenario matrix, browser, logs, tests, rubric"
+proof: "Every scenario meets its original success criteria"
+stop: "The full scenario set passes under the same conditions"
+memory: "Store scenarios, evidence, scores, and fixes in an evaluation report"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - evaluation
+  - qa
+  - release
+---
+
+## Loop
+
+Use this to test a product as users actually experience it.
+
+1. List realistic scenarios that cover the major capabilities.
+2. Define pass/fail checks or scoring criteria before testing.
+3. Run each scenario under consistent conditions.
+4. Record screenshots, logs, outputs, and failure notes.
+5. Fix root causes for failed scenarios.
+6. Rerun affected scenarios, then rerun the full set.
+
+Stop when the full scenario set passes against the original criteria.

--- a/_loops/goal-test-suite-migration-loop.md
+++ b/_loops/goal-test-suite-migration-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Goal with test-suite oracle"
+excerpt: "Give a long-running agent migration a hard finish line by requiring it to satisfy an existing test suite."
+category: "Engineering"
+trigger: "A port, rewrite, or migration has a trusted reference test suite"
+cadence: "Until the goal is complete or blocked"
+tooling: "Goal runner, original tests, build logs, implementation repo"
+proof: "The target implementation passes the reference tests"
+stop: "The full reference suite passes or a blocker is documented"
+memory: "Persist failing tests, fixes, and remaining incompatibilities"
+source_title: "Codex-maxxing"
+source_url: "https://jxnl.co/writing/2026/05/10/codex-maxxing/"
+attribution: "Jason Liu"
+status: curated
+tags:
+  - migration
+  - goals
+  - tests
+---
+
+## Loop
+
+Use this when a large task needs an external oracle instead of vibes.
+
+1. Identify the reference implementation and test suite.
+2. Make the success condition explicit: the new implementation must pass those tests.
+3. Run the tests before changing code and record the baseline.
+4. Implement in small passes.
+5. Rerun failing tests after each pass.
+6. Keep a compatibility ledger for known gaps.
+
+Stop when the reference suite passes or the blocker is precise enough for a human decision.

--- a/_loops/memory-diff-workstream-loop.md
+++ b/_loops/memory-diff-workstream-loop.md
@@ -1,0 +1,32 @@
+---
+layout: loop
+title: "Memory diff workstream loop"
+excerpt: "Keep a long-running workstream grounded by writing decisions and open loops to disk, then reviewing the diff."
+category: "Operations"
+trigger: "A persistent agent thread learns something durable"
+cadence: "At the end of each meaningful work session"
+tooling: "Notes repo, Git, project memory, PR diff"
+proof: "Memory updates are reviewable as file diffs"
+stop: "New decisions, preferences, blockers, and closed loops are recorded"
+memory: "The notes repo is the source of truth"
+source_title: "Codex-maxxing"
+source_url: "https://jxnl.co/writing/2026/05/10/codex-maxxing/"
+attribution: "Jason Liu"
+status: curated
+tags:
+  - memory
+  - workstreams
+  - notes
+---
+
+## Loop
+
+Use this when a thread or agent should survive beyond one chat.
+
+1. Keep workstream notes in version-controlled files.
+2. Ask the agent to update people, projects, decisions, and open-loop pages as it learns.
+3. Keep updates concise and inspectable.
+4. Review the diff before accepting memory changes.
+5. Remove stale or speculative notes.
+
+Stop when durable context is in files and the diff accurately reflects what changed.

--- a/_loops/nightly-changelog-loop.md
+++ b/_loops/nightly-changelog-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Nightly changelog loop"
+excerpt: "Review the day's changes and update the changelog with user-visible updates or a recorded no-change result."
+category: "Documentation"
+trigger: "A development day ends"
+cadence: "Nightly"
+tooling: "Git history, PRs, issue tracker, changelog"
+proof: "User-relevant changes are reflected in the changelog"
+stop: "Changelog is updated and validated, or no user-facing changes are recorded"
+memory: "Store the date, reviewed commits, and release-note decision"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - changelog
+  - documentation
+  - release-notes
+---
+
+## Loop
+
+Use this to keep release notes from becoming a late-stage archaeology project.
+
+1. Inspect merged PRs, commits, and shipped issues for the day.
+2. Separate internal-only changes from user-visible changes.
+3. Add concise changelog entries for user-visible behavior.
+4. Link source PRs or issues where useful.
+5. Validate formatting and links.
+6. Record a no-change note when nothing user-visible shipped.
+
+Stop when every user-facing change has a changelog entry or an explicit no-change record exists.

--- a/_loops/overnight-docs-sweep.md
+++ b/_loops/overnight-docs-sweep.md
@@ -1,0 +1,32 @@
+---
+layout: loop
+title: "Overnight docs sweep"
+excerpt: "Review recent code changes, update stale documentation, and open a focused PR before the next workday."
+category: "Documentation"
+trigger: "Code changes landed since the last docs sweep"
+cadence: "Nightly"
+tooling: "Git diff, docs, build, link checker, GitHub"
+proof: "Docs match the current implementation and checks pass"
+stop: "A focused docs PR is open or no stale docs are found"
+memory: "Record reviewed commits and unchanged docs areas"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - documentation
+  - pull-request
+  - maintenance
+---
+
+## Loop
+
+Use this when code moves faster than docs.
+
+1. Inspect commits, merged PRs, and changed files since the last sweep.
+2. Identify docs that mention changed behavior, APIs, commands, or workflows.
+3. Update only the docs affected by those changes.
+4. Run the docs build, link check, or project validation.
+5. Open a PR with the evidence and reviewed commit range.
+
+Stop when the docs are current for the reviewed range or the sweep records that no docs changed.

--- a/_loops/post-release-baseline-loop.md
+++ b/_loops/post-release-baseline-loop.md
@@ -1,0 +1,32 @@
+---
+layout: loop
+title: "Post-release baseline loop"
+excerpt: "After a release lands, rerun standard benchmarks and store the new baseline with environment details."
+category: "Release"
+trigger: "A release finishes deploying"
+cadence: "After each release"
+tooling: "Benchmark suite, release SHA, environment metadata"
+proof: "Baseline results are tied to the released revision"
+stop: "Results, conditions, and benchmark version are recorded"
+memory: "Append baseline data to the performance history"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - benchmarks
+  - release
+  - performance
+---
+
+## Loop
+
+Use this to keep performance comparisons honest across releases.
+
+1. Wait until the release is deployed and stable.
+2. Capture release SHA, environment, benchmark version, and test conditions.
+3. Run the standard benchmark suite.
+4. Compare against the prior baseline and flag large movement.
+5. Store the new baseline with enough context to reproduce it.
+
+Stop when the release has a benchmark record that future runs can compare against.

--- a/_loops/production-data-cleanup-loop.md
+++ b/_loops/production-data-cleanup-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Production data cleanup loop"
+excerpt: "Audit records against an allowed definition, clean invalid data, improve classification, and prove the retained data is valid."
+category: "Data quality"
+trigger: "Production data contains stale, invalid, duplicate, or disallowed records"
+cadence: "Per cleanup batch"
+tooling: "Database queries, classifier tests, audit report, backup"
+proof: "Post-cleanup sample and tests show remaining records meet the allowed definition"
+stop: "No reviewed record violates the allowed definition"
+memory: "Log removed records, rules changed, and audit sample"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - data-quality
+  - production
+  - cleanup
+---
+
+## Loop
+
+Use this when data cleanup needs repeatable proof rather than one-off deletion.
+
+1. Define the allowed record criteria before touching data.
+2. Query candidate records and sample edge cases.
+3. Back up or export the affected set.
+4. Remove or repair only records that fail the definition.
+5. Improve classification logic so the issue is less likely to recur.
+6. Run post-cleanup audits and representative tests.
+
+Stop when retained records pass the definition and cleanup evidence is recorded.

--- a/_loops/production-error-sweep.md
+++ b/_loops/production-error-sweep.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Production error sweep"
+excerpt: "Scan production logs, fix actionable root causes, verify the fix, and send a concise status update."
+category: "Operations"
+trigger: "Production logs or monitoring may contain new actionable errors"
+cadence: "Hourly, daily, or after deploy"
+tooling: "Logs, traces, issue tracker, tests, GitHub, Slack"
+proof: "Error is reproduced or traced, fix is verified, and PR links evidence"
+stop: "Actionable errors are fixed or a clean-log confirmation is posted"
+memory: "Record incident, root cause, fix link, and prevention note"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - production
+  - logs
+  - incident
+---
+
+## Loop
+
+Use this as an operational maintenance check.
+
+1. Review production logs and monitoring for new high-signal errors.
+2. Ignore noise only after explaining why it is not actionable.
+3. Trace each actionable issue to a likely root cause.
+4. Write or update a regression test when possible.
+5. Fix the root cause and verify the original signal is gone.
+6. Open a PR or post a clean-log summary.
+
+Stop when every reviewed error is resolved, owned, or explicitly not actionable.

--- a/_loops/quality-streak-loop.md
+++ b/_loops/quality-streak-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Quality streak loop"
+excerpt: "Run realistic cases until N pass in a row, restarting the streak whenever a failure is found and fixed."
+category: "Evaluation"
+trigger: "A workflow needs confidence under varied realistic inputs"
+cadence: "Before release or after major fixes"
+tooling: "Scenario generator, browser, tests, benchmark log"
+proof: "The latest N realistic scenarios pass consecutively"
+stop: "N consecutive scenarios pass with failures documented and protected"
+memory: "Track failed cases, fixes, regression tests, and streak count"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - evaluation
+  - qa
+  - regression
+---
+
+## Loop
+
+Use this to force a workflow through varied examples without accepting a lucky pass.
+
+1. Choose the required streak length before testing.
+2. Generate or select realistic scenarios one at a time.
+3. Run each scenario and record evidence.
+4. When a scenario fails, document it, fix the root cause, and add regression coverage.
+5. Reset the streak after every failure.
+6. Continue until the target streak passes.
+
+Stop when the latest N scenarios pass in a row and every earlier failure has a regression guard.

--- a/_loops/repository-cleanup-loop.md
+++ b/_loops/repository-cleanup-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Repository cleanup loop"
+excerpt: "Inspect branches, worktrees, commits, and PRs; recover valuable work and remove stale state with evidence."
+category: "Engineering"
+trigger: "A repository has stale branches, abandoned PRs, or unclear local state"
+cadence: "Weekly or before release"
+tooling: "Git, GitHub CLI, worktrees, issue tracker"
+proof: "Remaining repo state is current, owned, or intentionally archived"
+stop: "No valuable work is stranded and stale state is removed or documented"
+memory: "Record recovered work, deleted branches, and owners"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - git
+  - cleanup
+  - maintenance
+---
+
+## Loop
+
+Use this when repo state has become hard to trust.
+
+1. List local branches, remote branches, open PRs, closed PRs, and worktrees.
+2. Identify unmerged commits and owners.
+3. Recover valuable work by opening or updating PRs.
+4. Archive or delete stale branches only after confirming no useful commits remain.
+5. Prune unused worktrees and stale remotes.
+6. Summarize what was recovered, retained, and removed.
+
+Stop when every remaining branch and PR has a clear owner or purpose.

--- a/_loops/seo-geo-visibility-loop.md
+++ b/_loops/seo-geo-visibility-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "SEO and GEO visibility loop"
+excerpt: "Audit indexability, answer readiness, structured data, and query coverage, then fix the highest-impact gap and rerun the benchmark."
+category: "Growth"
+trigger: "Priority pages are not earning search or AI-answer visibility"
+cadence: "Weekly or per content batch"
+tooling: "Crawler, search console, answer-engine benchmark, schema validator"
+proof: "Priority queries map to technically sound, answer-ready pages"
+stop: "No high-impact technical or intent gap remains in the benchmark"
+memory: "Keep crawl results, query benchmarks, fixes, and remaining backlog"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - seo
+  - geo
+  - growth
+---
+
+## Loop
+
+Use this to turn SEO and AI-answer optimization into a repeatable operating cycle.
+
+1. Crawl priority pages for indexability, canonicals, metadata, internal links, and structured data.
+2. Run a target-query benchmark across search and answer engines.
+3. Map every priority query to an answer-ready page.
+4. Rank gaps by expected traffic or conversion impact.
+5. Fix the highest-leverage gap.
+6. Rerun the same crawl and query benchmark.
+
+Stop when priority pages are crawlable, answer-ready, and no high-impact gap remains.

--- a/_loops/stale-safe-batch-release-loop.md
+++ b/_loops/stale-safe-batch-release-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Stale-safe batch release loop"
+excerpt: "Review pending changes, exclude stale or unfinished work, combine only valid changes, and release from current main."
+category: "Release"
+trigger: "Multiple pending changes need to ship together"
+cadence: "Per batch release"
+tooling: "GitHub, CI, release notes, deployment dashboard"
+proof: "Only current and complete changes are included in the release"
+stop: "The released revision is current main with every selected change integrated"
+memory: "Record included PRs, excluded work, release SHA, and validation"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - release
+  - pull-request
+  - ci
+---
+
+## Loop
+
+Use this when a batch release risks accidentally shipping stale work.
+
+1. List candidate PRs and pending local changes.
+2. Exclude anything stale, failing, unreviewed, or unfinished.
+3. Rebase or update selected work onto current main.
+4. Run CI and release checks on the integrated revision.
+5. Ship only the selected current changes.
+6. Record what shipped and what was deferred.
+
+Stop when the deployed revision matches the selected batch and all excluded work is documented.

--- a/_loops/support-refund-polling-loop.md
+++ b/_loops/support-refund-polling-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Support refund polling loop"
+excerpt: "Poll a customer-support chat until an agent joins, then respond quickly with the goal and evidence."
+category: "Customer support"
+trigger: "A support chat is waiting for a human agent"
+cadence: "Every 5 minutes until joined, then every minute"
+tooling: "Browser or computer control, order details, support chat"
+proof: "Support agent response and refund or escalation result are captured"
+stop: "Refund is completed, escalation is logged, or human input is required"
+memory: "Store order, timestamps, support outcome, and follow-up needs"
+source_title: "Codex-maxxing"
+source_url: "https://jxnl.co/writing/2026/05/10/codex-maxxing/"
+attribution: "Jason Liu"
+status: curated
+tags:
+  - support
+  - polling
+  - browser
+---
+
+## Loop
+
+Use this for support queues where the expensive part is waiting and responding promptly.
+
+1. Keep the support chat open.
+2. Poll at a low cadence while waiting for an agent.
+3. Once an agent joins, increase cadence.
+4. Present the concise goal, account/order context, and relevant evidence.
+5. Respond to questions without inventing facts.
+6. Capture the final outcome.
+
+Stop when the refund is complete, the case is escalated, or the agent asks for information only the user can provide.

--- a/_loops/test-suite-speed-loop.md
+++ b/_loops/test-suite-speed-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Test-suite speed loop"
+excerpt: "Make a test suite faster without losing coverage or behavior, proving each improvement with repeatable timing."
+category: "Engineering"
+trigger: "Test runtime slows development or CI"
+cadence: "Per performance improvement batch"
+tooling: "Test runner, coverage report, profiler, CI"
+proof: "Suite is faster with no coverage or behavior regression"
+stop: "Timing target is met or remaining slowness has owners"
+memory: "Record baseline, changes, timing method, and final runtime"
+source_title: "Forward Future Loop Library"
+source_url: "https://signals.forwardfuture.ai/loop-library/#top"
+attribution: "Matthew Berman"
+status: curated
+tags:
+  - tests
+  - performance
+  - ci
+---
+
+## Loop
+
+Use this when slow tests are causing real workflow drag.
+
+1. Capture a timing baseline under repeatable conditions.
+2. Identify the slowest tests or setup phases.
+3. Improve one bottleneck at a time without deleting coverage.
+4. Run the full suite and coverage report after each meaningful change.
+5. Compare against the baseline with the same timing method.
+6. Document any tradeoffs.
+
+Stop when the target runtime is reached or remaining work is explicit and owned.

--- a/_loops/visual-verification-loop.md
+++ b/_loops/visual-verification-loop.md
@@ -1,0 +1,33 @@
+---
+layout: loop
+title: "Visual verification loop"
+excerpt: "Compare the implemented UI against a screenshot or design, list differences, fix them, and repeat."
+category: "Evaluation"
+trigger: "A UI change needs visual fidelity"
+cadence: "Per UI change"
+tooling: "Browser screenshot, design reference, console, responsive viewports"
+proof: "Screenshots show the implemented UI matches the target within agreed differences"
+stop: "No material visual differences remain across target viewports"
+memory: "Attach before and after screenshots to the PR"
+source_title: "Claude Code best practices"
+source_url: "https://code.claude.com/docs/en/best-practices"
+attribution: "Anthropic"
+status: curated
+tags:
+  - ui
+  - screenshots
+  - qa
+---
+
+## Loop
+
+Use this when "looks good" needs evidence.
+
+1. Capture or attach the target visual reference.
+2. Implement the UI change.
+3. Take screenshots at the required viewport sizes.
+4. Compare the result against the target and list differences.
+5. Fix material differences.
+6. Repeat until the comparison is clean.
+
+Stop when screenshots prove the accepted design state across target viewports.

--- a/_plugins/markdown_twin_generator.rb
+++ b/_plugins/markdown_twin_generator.rb
@@ -81,6 +81,7 @@ module Jekyll
 
       attach_twin(site, :post) { |list| list.concat(site.posts.docs) }
       attach_twin(site, :book) { |list| list.concat(site.collections.fetch("books", Collection.new(site, "books")).docs) }
+      attach_twin(site, :loop) { |list| list.concat(site.collections.fetch("loops", Collection.new(site, "loops")).docs) }
       attach_twin(site, :page) do |list|
         site.pages.each do |page|
           list << page if page.url.end_with?("/")
@@ -132,6 +133,8 @@ module Jekyll
       when :post
         [twin_url, document_twin(source, include_date: true)]
       when :book
+        [twin_url, document_twin(source, include_date: false)]
+      when :loop
         [twin_url, document_twin(source, include_date: false)]
       when :page
         [twin_url, page_twin(source)]

--- a/assets/css/pages/loop-marketplace.css
+++ b/assets/css/pages/loop-marketplace.css
@@ -1,0 +1,473 @@
+.loop-marketplace,
+.loop-detail {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 20px 40px;
+}
+
+.loop-hero,
+.loop-submit,
+.loop-detail-header {
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 28px;
+  margin-bottom: 28px;
+}
+
+.loop-eyebrow,
+.loop-card-meta {
+  color: #2f6f64;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 10px;
+  text-transform: uppercase;
+}
+
+.loop-hero h1,
+.loop-detail-header h1 {
+  font-size: 44px;
+  line-height: 1.05;
+  margin: 0 0 16px;
+}
+
+.loop-hero p,
+.loop-detail-header p,
+.loop-submit-header p {
+  color: var(--text-secondary);
+  font-size: 16px;
+  max-width: 760px;
+}
+
+.loop-hero-actions,
+.loop-form-actions,
+.loop-card-footer,
+.loop-tags,
+.loop-source-strip,
+.loop-breadcrumbs ol,
+.loop-back-link,
+.loop-detail-footer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.loop-hero-actions {
+  margin: 24px 0;
+}
+
+.loop-hero-actions a,
+.loop-form-actions button,
+.loop-detail-footer a,
+.loop-back-link {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  min-height: 40px;
+  padding: 9px 14px;
+  text-decoration: none;
+}
+
+.loop-hero-actions .loop-primary-action,
+.loop-form-actions button[type="submit"] {
+  background: #183f3a;
+  border-color: #183f3a;
+  color: #ffffff;
+}
+
+.loop-stats,
+.loop-detail-grid,
+.loop-card-contract {
+  display: grid;
+  gap: 12px;
+}
+
+.loop-stats {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  max-width: 620px;
+}
+
+.loop-stats div,
+.loop-detail-grid div,
+.loop-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+
+.loop-stats div {
+  padding: 14px;
+}
+
+.loop-stats dt {
+  color: var(--text-primary);
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.loop-stats dd {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin: 6px 0 0;
+}
+
+.loop-toolbar {
+  align-items: end;
+  display: grid;
+  grid-template-columns: auto minmax(220px, 1fr) auto minmax(160px, 240px) auto;
+  gap: 10px;
+  margin: 0 0 24px;
+}
+
+.loop-toolbar label,
+.loop-form-row label,
+.loop-generated label {
+  color: var(--text-secondary);
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.loop-toolbar input,
+.loop-toolbar select,
+.loop-submit-form input,
+.loop-submit-form select,
+.loop-submit-form textarea,
+.loop-generated textarea {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font: inherit;
+  min-height: 40px;
+  padding: 9px 10px;
+  width: 100%;
+}
+
+.loop-toolbar output {
+  color: var(--text-secondary);
+  font-size: 13px;
+  padding-bottom: 10px;
+  white-space: nowrap;
+}
+
+.loop-listings {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 44px;
+}
+
+.loop-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 100%;
+  padding: 20px;
+}
+
+.loop-card[hidden] {
+  display: none;
+}
+
+.loop-card h2 {
+  font-size: 22px;
+  margin: 0 0 10px;
+}
+
+.loop-card h2 a {
+  color: var(--text-primary);
+}
+
+.loop-card p {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.loop-card-contract {
+  grid-template-columns: 1fr;
+}
+
+.loop-card-contract div {
+  border-left: 3px solid #d99042;
+  padding-left: 10px;
+}
+
+.loop-card-contract dt,
+.loop-detail-grid span,
+.loop-source-strip span {
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.loop-card-contract dd {
+  color: var(--text-primary);
+  margin: 2px 0 0;
+}
+
+.loop-tags span {
+  background: #eef4f2;
+  border: 1px solid #d7e6e2;
+  border-radius: 999px;
+  color: #204f49;
+  font-size: 12px;
+  padding: 3px 9px;
+}
+
+.loop-card-footer {
+  border-top: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 13px;
+  justify-content: space-between;
+  margin-top: auto;
+  padding-top: 14px;
+}
+
+.loop-submit {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 24px;
+}
+
+.loop-submit-header h2 {
+  font-size: 30px;
+  margin-bottom: 8px;
+}
+
+.loop-submit-form {
+  display: grid;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.loop-form-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.loop-form-row {
+  display: grid;
+  gap: 6px;
+}
+
+.loop-checkbox {
+  align-items: start;
+  color: var(--text-secondary);
+  display: flex;
+  gap: 10px;
+  line-height: 1.4;
+}
+
+.loop-checkbox input {
+  height: 18px;
+  margin-top: 2px;
+  min-height: 0;
+  width: 18px;
+}
+
+.loop-honeypot {
+  left: -9999px;
+  position: absolute;
+}
+
+.loop-generated {
+  display: grid;
+  gap: 8px;
+}
+
+.loop-generated p {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin: 0;
+}
+
+.loop-breadcrumbs {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin-bottom: 18px;
+}
+
+.loop-breadcrumbs ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.loop-breadcrumbs li {
+  align-items: center;
+  display: inline-flex;
+  gap: 12px;
+}
+
+.loop-breadcrumbs li + li::before {
+  color: var(--text-tertiary);
+  content: "/";
+}
+
+.loop-breadcrumbs a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.loop-breadcrumbs a:hover {
+  color: var(--text-primary);
+}
+
+.loop-back-link {
+  display: inline-flex;
+  margin-bottom: 18px;
+}
+
+.loop-detail-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 20px;
+}
+
+.loop-detail-grid div {
+  padding: 16px;
+}
+
+.loop-detail-grid strong {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  margin-top: 6px;
+}
+
+.loop-source-strip {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  margin-bottom: 22px;
+  padding: 12px 14px;
+}
+
+.loop-resource-links {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.loop-export-panel {
+  align-items: start;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
+  margin-bottom: 24px;
+  padding: 18px;
+}
+
+.loop-export-panel h2 {
+  font-size: 24px;
+  margin: 0 0 8px;
+}
+
+.loop-export-panel p {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.loop-export-hints {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+  margin: 12px 0 0;
+  padding-left: 18px;
+}
+
+.loop-export-hints li + li {
+  margin-top: 6px;
+}
+
+.loop-export-hints code {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 12px;
+  padding: 1px 4px;
+}
+
+.loop-export-actions {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.loop-export-actions button {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  min-height: 40px;
+  padding: 9px 10px;
+}
+
+.loop-export-actions button:hover,
+.loop-form-actions button:hover,
+.loop-hero-actions a:hover,
+.loop-detail-footer a:hover,
+.loop-back-link:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.loop-export-status {
+  grid-column: 1 / -1;
+  min-height: 20px;
+}
+
+.loop-body > * {
+  max-width: 880px;
+}
+
+.loop-detail-footer {
+  border-top: 1px solid var(--border-color);
+  margin-top: 34px;
+  padding-top: 18px;
+}
+
+@media screen and (max-width: 800px) {
+  .loop-hero h1,
+  .loop-detail-header h1 {
+    font-size: 34px;
+  }
+
+  .loop-toolbar,
+  .loop-listings,
+  .loop-form-grid,
+  .loop-detail-grid,
+  .loop-stats,
+  .loop-export-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .loop-export-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .loop-toolbar {
+    align-items: stretch;
+  }
+
+  .loop-toolbar output {
+    padding-bottom: 0;
+  }
+
+  .loop-submit {
+    padding: 18px;
+  }
+}

--- a/assets/js/pages/loop-marketplace.js
+++ b/assets/js/pages/loop-marketplace.js
@@ -1,0 +1,496 @@
+(function() {
+  "use strict";
+
+  function byId(id) {
+    return document.getElementById(id);
+  }
+
+  function slugify(value) {
+    return value
+      .toLowerCase()
+      .replace(/['"]/g, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80) || "submitted-loop";
+  }
+
+  function yamlString(value) {
+    return JSON.stringify((value || "").trim());
+  }
+
+  function present(value) {
+    return typeof value === "string" ? value.trim().length > 0 : Boolean(value);
+  }
+
+  function parseTags(value) {
+    return (value || "")
+      .split(",")
+      .map(function(tag) { return tag.trim(); })
+      .filter(Boolean);
+  }
+
+  function deriveExcerpt(instructions) {
+    var text = (instructions || "")
+      .replace(/^#+\s+/gm, "")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (!text) return "Community-submitted automation loop.";
+    if (text.length <= 220) return text;
+    return text.slice(0, 219).replace(/\s+\S*$/g, "") + ".";
+  }
+
+  function sourceTitleFromUrl(url) {
+    try {
+      return new URL(url).hostname.replace(/^www\./, "");
+    } catch (error) {
+      return (url || "").replace(/^https?:\/\//, "").replace(/\/$/, "");
+    }
+  }
+
+  function parseLinks(value) {
+    return (value || "")
+      .split(/\r?\n/)
+      .map(function(line) { return line.trim(); })
+      .filter(Boolean)
+      .map(function(line) {
+        var parts = line.split("|").map(function(part) { return part.trim(); }).filter(Boolean);
+        if (parts.length >= 2) {
+          return { title: parts[0], url: parts.slice(1).join(" | ") };
+        }
+
+        return { title: sourceTitleFromUrl(parts[0] || line), url: parts[0] || line };
+      })
+      .filter(function(link) { return present(link.url); });
+  }
+
+  function pushYamlField(lines, key, value) {
+    if (present(value)) lines.push(key + ": " + yamlString(value));
+  }
+
+  function buildMarkdown(form) {
+    var data = new FormData(form);
+    var title = data.get("title") || "Submitted loop";
+    var sourceUrl = data.get("source_url") || "";
+    var tags = parseTags(data.get("tags"));
+    var links = parseLinks(data.get("links"));
+    var instructions = (data.get("instructions") || "").trim();
+    var excerpt = (data.get("excerpt") || "").trim() || deriveExcerpt(instructions);
+
+    var frontMatter = [
+      "---",
+      "layout: loop",
+      "title: " + yamlString(title),
+      "excerpt: " + yamlString(excerpt),
+      "status: submitted"
+    ];
+
+    pushYamlField(frontMatter, "source_title", sourceUrl ? sourceTitleFromUrl(sourceUrl) : "");
+    pushYamlField(frontMatter, "source_url", sourceUrl);
+    pushYamlField(frontMatter, "attribution", data.get("attribution"));
+
+    if (tags.length > 0) {
+      frontMatter.push("tags:");
+      tags.forEach(function(tag) {
+        frontMatter.push("  - " + yamlString(tag));
+      });
+    }
+
+    if (links.length > 0) {
+      frontMatter.push("links:");
+      links.forEach(function(link) {
+        frontMatter.push("  - title: " + yamlString(link.title || sourceTitleFromUrl(link.url)));
+        frontMatter.push("    url: " + yamlString(link.url));
+      });
+    }
+
+    frontMatter.push("---");
+
+    return frontMatter.join("\n") + "\n\n## Loop\n\n" + instructions + "\n";
+  }
+
+  function loopTitle(loop) {
+    return (loop.title || "Automation loop").trim();
+  }
+
+  function normalizeInstructions(instructions) {
+    return (instructions || "").trim() || "Run the loop using the contract above. Collect proof before stopping.";
+  }
+
+  function loopSlug(loop) {
+    var raw = loop.slug || loopTitle(loop);
+    var slug = slugify(raw).slice(0, 64).replace(/-+$/g, "");
+    return slug || "automation-loop";
+  }
+
+  function compactText(value, fallback, limit) {
+    var text = (value || fallback || "").replace(/\s+/g, " ").trim();
+    if (text.length <= limit) return text;
+    return text.slice(0, limit - 1).replace(/\s+\S*$/g, "") + ".";
+  }
+
+  function skillDescription(loop) {
+    return compactText(
+      loop.excerpt || "Run this reviewed automation loop.",
+      "Run this reviewed automation loop.",
+      900
+    );
+  }
+
+  function detailRows(loop) {
+    return [
+      ["Category", loop.category],
+      ["Trigger", loop.trigger],
+      ["Cadence", loop.cadence],
+      ["Tooling", loop.tooling],
+      ["Proof", loop.proof],
+      ["Stop condition", loop.stop],
+      ["Memory", loop.memory]
+    ].filter(function(row) {
+      return present(row[1]);
+    });
+  }
+
+  function attributionRows(loop) {
+    var rows = [];
+    if (present(loop.sourceTitle) || present(loop.sourceUrl)) {
+      rows.push("- Source: " + (loop.sourceTitle || loop.sourceUrl) + (loop.sourceUrl ? " (" + loop.sourceUrl + ")" : ""));
+    }
+    if (present(loop.attribution)) rows.push("- Attribution: " + loop.attribution);
+    (loop.links || []).forEach(function(link) {
+      if (present(link.url)) rows.push("- " + (link.title || link.url) + ": " + link.url);
+    });
+    return rows;
+  }
+
+  function buildLoopPrompt(loop) {
+    var lines = [
+      "# " + loopTitle(loop),
+      "",
+      loop.excerpt || "",
+      "",
+      "## Instructions",
+      normalizeInstructions(loop.instructions)
+    ];
+    var details = detailRows(loop);
+    var attribution = attributionRows(loop);
+
+    if (details.length > 0) {
+      lines.push("", "## Details");
+      details.forEach(function(row) {
+        lines.push("- " + row[0] + ": " + row[1]);
+      });
+    }
+
+    if (attribution.length > 0) {
+      lines.push("", "## Links and Attribution");
+      Array.prototype.push.apply(lines, attribution);
+    }
+
+    return lines.join("\n").trim() + "\n";
+  }
+
+  function buildSkill(loop) {
+    var slug = loopSlug(loop);
+    var metadata = [
+      "  marketplace_url: " + yamlString(window.location.href.split("#")[0])
+    ];
+    if (present(loop.sourceTitle)) metadata.push("  source_title: " + yamlString(loop.sourceTitle));
+    if (present(loop.sourceUrl)) metadata.push("  source_url: " + yamlString(loop.sourceUrl));
+    if (present(loop.attribution)) metadata.push("  attribution: " + yamlString(loop.attribution));
+
+    var lines = [
+      "---",
+      "name: " + yamlString(slug),
+      "description: " + yamlString(skillDescription(loop)),
+      "disable-model-invocation: true",
+      "metadata:",
+    ].concat(metadata).concat([
+      "---",
+      "",
+      "# " + loopTitle(loop),
+      "",
+      "Use this skill to run the automation loop below. Confirm it matches the user's task before taking action.",
+      "",
+      "## Procedure",
+      "",
+      normalizeInstructions(loop.instructions)
+    ]);
+
+    var details = detailRows(loop);
+    var attribution = attributionRows(loop);
+
+    if (details.length > 0) {
+      lines.push("", "## Optional Details", "");
+      details.forEach(function(row) {
+        lines.push("- " + row[0] + ": " + row[1]);
+      });
+    }
+
+    if (attribution.length > 0) {
+      lines.push("", "## Links and Attribution", "");
+      Array.prototype.push.apply(lines, attribution);
+    }
+
+    return lines.join("\n");
+  }
+
+  function buildAgentsBlock(loop) {
+    var lines = [
+      "## Automation loop: " + loopTitle(loop),
+      "",
+      "Use this loop when the task matches this workflow.",
+      ""
+    ];
+    if (present(loop.trigger)) lines.splice(2, 1, "Use this loop when: " + loop.trigger + ".");
+    if (present(loop.proof)) lines.push("Before stopping, collect this proof: " + loop.proof + ".", "");
+    lines.push(buildLoopPrompt(loop));
+    return lines.join("\n");
+  }
+
+  function buildCursorRule(loop) {
+    return [
+      "---",
+      "description: " + yamlString(skillDescription(loop)),
+      "alwaysApply: false",
+      "---",
+      "",
+      buildLoopPrompt(loop)
+    ].join("\n");
+  }
+
+  function readLoopData() {
+    var node = byId("loop-export-data");
+    if (!node) return null;
+
+    try {
+      return JSON.parse(node.textContent);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function setExportStatus(message) {
+    var status = byId("loop-export-status");
+    if (status) status.textContent = message;
+  }
+
+  function exportText(kind, loop) {
+    if (kind === "skill") return buildSkill(loop);
+    if (kind === "agents") return buildAgentsBlock(loop);
+    if (kind === "cursor") return buildCursorRule(loop);
+    return buildLoopPrompt(loop);
+  }
+
+  function extensionForKind(kind) {
+    if (kind === "cursor") return ".mdc";
+    return ".md";
+  }
+
+  function filenameForKind(kind, loop) {
+    if (kind === "skill") return "SKILL.md";
+    return loopSlug(loop) + extensionForKind(kind);
+  }
+
+  function deepLink(kind, loop) {
+    var prompt = buildLoopPrompt(loop);
+    var promptText = encodeURIComponent(prompt);
+
+    if (kind === "claude") {
+      if (prompt.length > 5000) {
+        return {
+          error: "Claude deep links support prompts up to 5,000 characters. Copy the prompt instead."
+        };
+      }
+
+      return {
+        url: "claude-cli://open?q=" + promptText,
+        message: "Opening Claude Code with a prompt preview. Review it before running."
+      };
+    }
+
+    if (kind === "cursor-prompt") {
+      return cursorDeepLink("prompt", "", prompt);
+    }
+
+    if (kind === "cursor-rule") {
+      return cursorDeepLink("rule", loopSlug(loop), buildCursorRule(loop));
+    }
+
+    return { error: "Unknown export action." };
+  }
+
+  function cursorDeepLink(type, name, text) {
+    var query = new URLSearchParams();
+    if (name) query.set("name", name);
+    query.set("text", text);
+
+    var url = "cursor://anysphere.cursor-deeplink/" + type + "?" + query.toString();
+    if (url.length > 8000) {
+      return {
+        error: "Cursor deep links support URLs up to 8,000 characters. Copy or download the export instead."
+      };
+    }
+
+    return {
+      url: url,
+      message: "Opening Cursor with a review step. Nothing runs until you confirm it."
+    };
+  }
+
+  function copyText(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+
+    var textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.select();
+    var ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok ? Promise.resolve() : Promise.reject(new Error("copy failed"));
+  }
+
+  function downloadText(filename, text) {
+    var blob = new Blob([text], { type: "text/markdown;charset=utf-8" });
+    var url = URL.createObjectURL(blob);
+    var link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  function updateFilters() {
+    var search = (byId("loop-search") || {}).value || "";
+    var category = (byId("loop-category") || {}).value || "";
+    var query = search.trim().toLowerCase();
+    var cards = Array.prototype.slice.call(document.querySelectorAll(".loop-card"));
+    var visible = 0;
+
+    cards.forEach(function(card) {
+      var textMatch = !query || (card.getAttribute("data-search") || "").indexOf(query) !== -1;
+      var categoryMatch = !category || card.getAttribute("data-category") === category;
+      var show = textMatch && categoryMatch;
+      card.hidden = !show;
+      if (show) visible += 1;
+    });
+
+    var count = byId("loop-count");
+    if (count) count.textContent = visible + (visible === 1 ? " loop" : " loops");
+  }
+
+  function showGenerated(markdown, note) {
+    var panel = byId("loop-generated");
+    var textarea = byId("loop-generated-markdown");
+    var noteEl = byId("loop-generated-note");
+
+    if (!panel || !textarea) return;
+    textarea.value = markdown;
+    panel.hidden = false;
+    if (noteEl) noteEl.textContent = note || "";
+  }
+
+  function initLoopMarketplace() {
+    var search = byId("loop-search");
+    var category = byId("loop-category");
+    var form = byId("loop-submit-form");
+    var preview = byId("loop-preview-button");
+    var root = document.querySelector(".loop-marketplace");
+
+    if (search) search.addEventListener("input", updateFilters);
+    if (category) category.addEventListener("change", updateFilters);
+
+    if (preview && form) {
+      preview.addEventListener("click", function() {
+        showGenerated(buildMarkdown(form), "Preview generated. Submit opens GitHub with this Markdown.");
+      });
+    }
+
+    if (form && root) {
+      form.addEventListener("submit", function(event) {
+        event.preventDefault();
+
+        if (form.elements.company && form.elements.company.value) return;
+        if (!form.checkValidity()) {
+          form.reportValidity();
+          return;
+        }
+
+        var markdown = buildMarkdown(form);
+        var title = new FormData(form).get("title") || "Submitted loop";
+        var filename = slugify(title) + ".md";
+        var params = new URLSearchParams({
+          filename: filename,
+          value: markdown,
+          message: "Add loop: " + title
+        });
+        var url = root.getAttribute("data-github-new-url") + "?" + params.toString();
+
+        showGenerated(markdown, "Opening GitHub. Use Propose new file, then Create pull request.");
+
+        if (url.length > 7000) {
+          byId("loop-generated-note").textContent = "This loop is long. Copy the Markdown into _loops/" + filename + " and open a pull request.";
+          return;
+        }
+
+        window.open(url, "_blank", "noopener");
+      });
+    }
+
+    var loop = readLoopData();
+    if (loop) {
+      document.querySelectorAll("[data-loop-export]").forEach(function(button) {
+        button.addEventListener("click", function() {
+          var kind = button.getAttribute("data-loop-export");
+          copyText(exportText(kind, loop))
+            .then(function() {
+              setExportStatus("Copied " + button.textContent.trim() + ".");
+            })
+            .catch(function() {
+              setExportStatus("Copy failed. Use Download instead.");
+            });
+        });
+      });
+
+      document.querySelectorAll("[data-loop-download]").forEach(function(button) {
+        button.addEventListener("click", function() {
+          var kind = button.getAttribute("data-loop-download");
+          downloadText(filenameForKind(kind, loop), exportText(kind, loop));
+          if (kind === "skill") {
+            setExportStatus("Downloaded SKILL.md. Place it in a folder named " + loopSlug(loop) + " under .agents/skills, .claude/skills, or .cursor/skills.");
+          } else {
+            setExportStatus("Downloaded " + filenameForKind(kind, loop) + ". Place it under .cursor/rules/.");
+          }
+        });
+      });
+
+      document.querySelectorAll("[data-loop-open]").forEach(function(button) {
+        button.addEventListener("click", function() {
+          var link = deepLink(button.getAttribute("data-loop-open"), loop);
+
+          if (link.error) {
+            setExportStatus(link.error);
+            return;
+          }
+
+          setExportStatus(link.message);
+          window.location.href = link.url;
+        });
+      });
+    }
+
+    updateFilters();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initLoopMarketplace);
+  } else {
+    initLoopMarketplace();
+  }
+})();

--- a/awesome-loops/automation.md
+++ b/awesome-loops/automation.md
@@ -1,0 +1,183 @@
+---
+layout: page
+title: Loops
+description: A curated marketplace of repeatable automation loops for coding agents, research agents, operations, growth, evaluation, and customer workflows.
+permalink: /awesome-loops/automation/
+includelink: true
+custom_layout: true
+page_stylesheets:
+  - /assets/css/pages/loop-marketplace.css
+page_scripts:
+  - /assets/js/pages/loop-marketplace.js
+---
+
+{% assign loops = site.loops | sort: "title" %}
+{% assign categorized_loops = site.loops | where_exp: "loop", "loop.category" %}
+{% assign categories = categorized_loops | map: "category" | uniq | sort %}
+
+<div class="loop-marketplace" data-github-new-url="https://github.com/subramanya1997/subramanya1997.github.io/new/main/_loops">
+  <header class="loop-hero">
+    <p class="loop-eyebrow">awesome-loops / automation</p>
+    <h1>Automation loop marketplace</h1>
+    <p>Curated agent loops as copyable prompts, Agent Skills, Codex instructions, and Cursor rules. Every listing is Markdown, optional metadata stays optional, and every community submission goes through pull-request review.</p>
+    <div class="loop-hero-actions">
+      <a href="#submit-loop" class="loop-primary-action">Submit loop</a>
+      <a href="https://github.com/subramanya1997/subramanya1997.github.io/tree/main/_loops" rel="noopener noreferrer">Browse Markdown</a>
+    </div>
+    <dl class="loop-stats" aria-label="Marketplace stats">
+      <div>
+        <dt>{{ site.loops.size }}</dt>
+        <dd>Listings</dd>
+      </div>
+      <div>
+        <dt>1</dt>
+        <dd>Markdown file per loop</dd>
+      </div>
+      <div>
+        <dt>PR</dt>
+        <dd>Review gate</dd>
+      </div>
+    </dl>
+  </header>
+
+  <section class="loop-toolbar" aria-label="Marketplace filters">
+    <label for="loop-search">Search</label>
+    <input id="loop-search" type="search" placeholder="Search loops, links, source, or attribution" autocomplete="off">
+
+    {% if categories.size > 0 %}
+      <label for="loop-category">Category</label>
+      <select id="loop-category">
+        <option value="">All categories</option>
+        {% for category in categories %}
+          <option value="{{ category | downcase | escape }}">{{ category }}</option>
+        {% endfor %}
+      </select>
+    {% endif %}
+
+    <output id="loop-count" aria-live="polite">{{ site.loops.size }} loops</output>
+  </section>
+
+  <section class="loop-listings" aria-label="Automation loop listings">
+    {% for loop in loops %}
+      {% assign loop_search_text = loop.title | append: " " | append: loop.excerpt | append: " " | append: loop.content | append: " " | append: loop.category | append: " " | append: loop.tooling | append: " " | append: loop.proof | append: " " | append: loop.stop | append: " " | append: loop.source_title | append: " " | append: loop.attribution | append: " " | append: loop.tags | append: " " | append: loop.links | downcase %}
+      <article class="loop-card" data-category="{{ loop.category | downcase | escape }}" data-search="{{ loop_search_text | strip_html | escape }}">
+        <div class="loop-card-header">
+          {% if loop.category or loop.status %}
+            <p class="loop-card-meta">
+              {% if loop.category %}{{ loop.category }}{% endif %}
+              {% if loop.category and loop.status %} / {% endif %}
+              {% if loop.status %}{{ loop.status }}{% endif %}
+            </p>
+          {% endif %}
+          <h2><a href="{{ loop.url | prepend: site.baseurl }}">{{ loop.title }}</a></h2>
+          <p>{{ loop.excerpt }}</p>
+        </div>
+
+        {% if loop.proof or loop.stop %}
+          <dl class="loop-card-contract">
+            {% if loop.proof %}
+              <div>
+                <dt>Verify</dt>
+                <dd>{{ loop.proof }}</dd>
+              </div>
+            {% endif %}
+            {% if loop.stop %}
+              <div>
+                <dt>Stop</dt>
+                <dd>{{ loop.stop }}</dd>
+              </div>
+            {% endif %}
+          </dl>
+        {% endif %}
+
+        {% if loop.tags %}
+          <div class="loop-tags" aria-label="Tags">
+            {% for tag in loop.tags %}
+              <span>{{ tag }}</span>
+            {% endfor %}
+          </div>
+        {% endif %}
+
+        {% if loop.source_url or loop.source_title or loop.attribution or loop.links %}
+          <div class="loop-card-footer">
+            {% if loop.source_url %}
+              <a href="{{ loop.source_url }}" rel="noopener noreferrer">{{ loop.source_title | default: loop.source_url }}</a>
+            {% elsif loop.source_title %}
+              <span>{{ loop.source_title }}</span>
+            {% endif %}
+            {% if loop.attribution %}
+              <span>{{ loop.attribution }}</span>
+            {% elsif loop.links %}
+              <span>{{ loop.links.size }} link{% if loop.links.size != 1 %}s{% endif %}</span>
+            {% endif %}
+          </div>
+        {% endif %}
+      </article>
+    {% endfor %}
+  </section>
+
+  <section class="loop-submit" id="submit-loop">
+    <div class="loop-submit-header">
+      <p class="loop-eyebrow">Contribute</p>
+      <h2>Submit a loop</h2>
+      <p>Send the prompt or instructions you actually use. Source, attribution, tags, and MCP/resource links are optional.</p>
+    </div>
+
+    <form class="loop-submit-form" id="loop-submit-form">
+      <input type="text" name="company" tabindex="-1" autocomplete="off" aria-hidden="true" class="loop-honeypot">
+
+      <div class="loop-form-row">
+        <label for="loop-title">Title *</label>
+        <input id="loop-title" name="title" required maxlength="90" placeholder="The production error sweep">
+      </div>
+
+      <div class="loop-form-row">
+        <label for="loop-excerpt">Short pitch optional</label>
+        <textarea id="loop-excerpt" name="excerpt" rows="2" maxlength="220" placeholder="Leave blank to derive this from the instructions."></textarea>
+      </div>
+
+      <div class="loop-form-grid">
+        <div class="loop-form-row">
+          <label for="loop-source-url">Source link optional</label>
+          <input id="loop-source-url" name="source_url" type="url" placeholder="https://example.com/source">
+        </div>
+
+        <div class="loop-form-row">
+          <label for="loop-attribution">Attribution optional</label>
+          <input id="loop-attribution" name="attribution" placeholder="Name, handle, or organization">
+        </div>
+      </div>
+
+      <div class="loop-form-row">
+        <label for="loop-links">MCP, repo, docs, or resource links optional</label>
+        <textarea id="loop-links" name="links" rows="3" placeholder="One per line. Use either https://example.com or Label | https://example.com"></textarea>
+      </div>
+
+      <div class="loop-form-row">
+        <label for="loop-tags-input">Tags optional</label>
+        <input id="loop-tags-input" name="tags" placeholder="engineering, logs, pr-review">
+      </div>
+
+      <div class="loop-form-row">
+        <label for="loop-instructions">Loop instructions *</label>
+        <textarea id="loop-instructions" name="instructions" required rows="8" placeholder="Paste the prompt or operating instructions. Keep secrets, private code, and private customer data out."></textarea>
+      </div>
+
+      <label class="loop-checkbox">
+        <input type="checkbox" name="rights" required>
+        <span>I have the right to share this loop and understand it may be edited before publication.</span>
+      </label>
+
+      <div class="loop-form-actions">
+        <button type="submit">Open PR contribution</button>
+        <button type="button" id="loop-preview-button">Preview Markdown</button>
+      </div>
+
+      <div class="loop-generated" id="loop-generated" hidden>
+        <label for="loop-generated-markdown">Generated Markdown</label>
+        <textarea id="loop-generated-markdown" readonly rows="12"></textarea>
+        <p id="loop-generated-note" aria-live="polite"></p>
+      </div>
+    </form>
+  </section>
+</div>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ This repository is a Jekyll-based personal site hosted on GitHub Pages. The site
 ## Build Flow
 
 1. Jekyll reads `_config.yml` to configure collections, URLs, markdown, and site-level metadata.
-2. Content is loaded from `_posts/`, `_books/`, top-level pages such as `index.html` and `blog.md`, and data files in `_data/`.
+2. Content is loaded from `_posts/`, `_books/`, `_loops/`, top-level pages such as `index.html` and `blog.md`, and data files in `_data/`.
 3. Layouts in `_layouts/` wrap page content and compose shared includes from `_includes/`.
 4. Static assets are served from `assets/`, `css/`, and top-level generated endpoints such as `feed.xml`, `search.json`, `llms.txt`, `llms-full.txt`, `/.well-known/api-catalog` (RFC 9727 API catalog, RFC 9264 Linkset), and `/.well-known/openid-configuration` (OIDC Discovery 1.0).
 5. Jekyll outputs the generated site to `_site/`.
@@ -25,6 +25,7 @@ This repository is a Jekyll-based personal site hosted on GitHub Pages. The site
 - `_includes/`: Shared partials such as head metadata, header/footer, header search form, TOC, analytics, newsletter UI, language switcher, translation toast, related posts, and generated tag archive markup.
 - `_posts/`: Blog posts in dated Markdown files.
 - `_books/`: The custom `books` collection.
+- `_loops/`: Curated automation-loop marketplace listings.
 - `_data/`: Structured data for the homepage, work page, i18n labels, and analytics-derived view counts.
 - `assets/`: Images, JavaScript, translation JSON, video, resume files, and page/component CSS introduced by the current refactor.
 - `css/main.css`: Global site styles shared across the whole site.
@@ -58,6 +59,7 @@ This repository is a Jekyll-based personal site hosted on GitHub Pages. The site
 - `_data/i18n.yml` stores UI strings for translation-related interfaces.
 - `_posts/` uses front matter plus Markdown body content for posts.
 - `_books/` uses front matter plus Markdown body content for the books collection.
+- `_loops/` uses front matter plus Markdown body content for automation-loop marketplace listings. Loop detail pages derive prompt, Agent Skill, Codex/Cursor `AGENTS.md`, Cursor `.mdc`, Claude deep-link, and Cursor deep-link exports from that source content.
 - `search.json` is the structured discovery index consumed by the search page.
 
 ## Runtime JavaScript Responsibilities
@@ -85,6 +87,7 @@ This repository is a Jekyll-based personal site hosted on GitHub Pages. The site
 - Homepage bio/work data: `_data/about.yaml`
 - Blog listing page: `blog.md`
 - Books listing page: `books.md`
+- Loop marketplace page: `awesome-loops/automation.md` and `_loops/*.md`
 - Work page: `work.md`
 - Stats page: `stats.md`
 - Post page layout and post-only UX: `_layouts/post.html`

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -52,6 +52,43 @@ Books live in `_books/` and are rendered through the `books` collection.
 - `author`
 - `ready`
 
+## Automation loops
+
+Automation loop listings live in `_loops/` and are rendered through the `loops` collection.
+
+### Required front matter
+
+- `layout`
+- `title`
+- `excerpt`
+
+The Markdown body is also required because it contains the loop prompt or operating instructions.
+
+### Optional front matter
+
+- `category`
+- `trigger`
+- `cadence`
+- `tooling`
+- `proof`
+- `stop`
+- `memory`
+- `source_title`
+- `source_url`
+- `attribution`
+- `status`
+- `tags`
+- `links`
+
+### Notes
+
+- `layout` should be `loop`.
+- `status`, when present, should be `curated`, `community`, or `submitted`.
+- `links`, when present, should be an array of mappings. Each link requires `url` and may include `title`.
+- The Markdown body should contain the actual loop prompt or operating instructions.
+- Public submissions should enter through a pull request so maintainers can validate safety, usefulness, and any optional attribution or resource links before merge.
+- Loop detail pages derive Agent Skill, Codex/Cursor `AGENTS.md`, Cursor `.mdc`, Claude deep-link, and Cursor deep-link exports from this same front matter plus body content.
+
 ## Non-publishable content
 
 - `_posts/readme.md` is documentation, not a publishable post.

--- a/docs/development.md
+++ b/docs/development.md
@@ -57,6 +57,18 @@ If CI fails, reproduce locally with the same commands first.
 2. Use the required front matter defined in `docs/content-model.md`.
 3. Run the validation commands.
 
+### Automation loops
+
+1. Add or update a Markdown listing in `_loops/`.
+2. Use the required front matter defined in `docs/content-model.md`.
+3. Keep the body concrete: it should be the actual prompt or operating instructions, not a vague idea.
+4. Treat source, attribution, category, trigger, cadence, tooling, proof, memory, stop condition, tags, and MCP/resource links as optional metadata.
+5. Community submissions should arrive as pull requests and should not be merged until safety, usefulness, and validation pass.
+6. Keep exports tool-aware: Agent Skills require `SKILL.md` inside a folder whose name matches the skill `name`, Cursor project rules require `.cursor/rules/*.mdc`, and Claude/Cursor deep links only open a review step in the local app.
+7. Run the validation commands.
+
+Loop PRs are routed through `.github/CODEOWNERS` and `.github/pull_request_template.md`. CODEOWNERS review is mandatory only when `main` branch protection requires code-owner approval.
+
 ### Data-driven pages
 
 - Homepage and work page content comes from `_data/about.yaml`.

--- a/llms.txt
+++ b/llms.txt
@@ -28,3 +28,9 @@ that prefer markdown can fetch those URLs directly or follow the
 {% for book in site.books %}
 - [{{ book.title }}]({{ site.url }}{{ book.web_url }}) (md: {{ site.url }}{{ book.url }}index.md)
 {% endfor %}
+
+## Automation Loop Marketplace
+- [Awesome Automation Loops]({{ site.url }}/awesome-loops/automation/) (md: {{ site.url }}/awesome-loops/automation/index.md)
+{% for loop in site.loops %}
+- [{{ loop.title }}]({{ site.url }}{{ loop.url }}) (md: {{ site.url }}{{ loop.url }}index.md): {{ loop.excerpt | strip_html | truncatewords: 20 }}
+{% endfor %}

--- a/scripts/validate_content.rb
+++ b/scripts/validate_content.rb
@@ -9,6 +9,7 @@ require "yaml"
 ROOT = Pathname(__dir__).join("..").expand_path
 POSTS_DIR = ROOT.join("_posts")
 BOOKS_DIR = ROOT.join("_books")
+LOOPS_DIR = ROOT.join("_loops")
 DATA_DIR = ROOT.join("_data")
 TOP_LEVEL_PAGES = %w[index.html blog.md books.md work.md stats.md].freeze
 FRONT_MATTER_PATTERN = /\A---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|\z)/m
@@ -21,6 +22,7 @@ class ValidationRunner
   def run
     validate_posts
     validate_books
+    validate_loops
     validate_about_data
     validate_view_count_data
     validate_top_level_page_asset_guard
@@ -53,6 +55,48 @@ class ValidationRunner
     BOOKS_DIR.glob("*.md").sort.each do |path|
       validate_front_matter(path, required_keys)
     end
+  end
+
+  def validate_loops
+    required_keys = %w[layout title excerpt]
+
+    LOOPS_DIR.glob("*.md").sort.each do |path|
+      validate_front_matter(path, required_keys)
+      validate_loop_body(path)
+      validate_loop_links(path)
+    end
+  end
+
+  def validate_loop_body(path)
+    _, body = parse_front_matter(path)
+    return if present?(body)
+
+    add_error("#{relative_path(path)}: loop body must contain the prompt or operating instructions")
+  rescue StandardError => e
+    add_error(e.message)
+  end
+
+  def validate_loop_links(path)
+    front_matter, = parse_front_matter(path)
+    links = stringify_keys(front_matter)["links"]
+    return unless links
+
+    unless links.is_a?(Array)
+      add_error("#{relative_path(path)}: links must be an array")
+      return
+    end
+
+    links.each_with_index do |link, index|
+      unless link.is_a?(Hash)
+        add_error("#{relative_path(path)}: links[#{index}] must be a mapping")
+        next
+      end
+
+      normalized = stringify_keys(link)
+      add_error("#{relative_path(path)}: links[#{index}] missing url") unless present?(normalized["url"])
+    end
+  rescue StandardError => e
+    add_error(e.message)
   end
 
   def validate_front_matter(path, required_keys)

--- a/search.json
+++ b/search.json
@@ -35,7 +35,7 @@ layout: none
           }{% unless forloop.last %},{% endunless %}
         {% endfor %}
       ]
-    }{% unless forloop.last and site.books.size == 0 %},{% endunless %}
+    }{% unless forloop.last and site.books.size == 0 and site.loops.size == 0 %},{% endunless %}
   {% endfor %}
   {% for book in site.books %}
     {
@@ -56,6 +56,28 @@ layout: none
             "name": {{ tag | jsonify }},
             "slug": {{ tag | slugify | jsonify }},
             "url": {{ tag_url | jsonify }}
+          }{% unless forloop.last %},{% endunless %}
+        {% endfor %}
+      ]
+    }{% unless forloop.last and site.loops.size == 0 %},{% endunless %}
+  {% endfor %}
+  {% for loop in site.loops %}
+    {
+      "kind": "loop",
+      "title": {{ loop.title | jsonify }},
+      "url": {{ loop.url | prepend: site.baseurl | jsonify }},
+      "date_display": null,
+      "date_iso": null,
+      "excerpt": {{ loop.excerpt | strip_html | strip_newlines | strip | jsonify }},
+      "content": {{ loop.content | strip_html | strip_newlines | jsonify }},
+      "views": null,
+      "reading_minutes": null,
+      "tags": [
+        {% for tag in loop.tags %}
+          {
+            "name": {{ tag | jsonify }},
+            "slug": {{ tag | slugify | jsonify }},
+            "url": {{ loop.url | prepend: site.baseurl | jsonify }}
           }{% unless forloop.last %},{% endunless %}
         {% endfor %}
       ]

--- a/sitemap-media.xml
+++ b/sitemap-media.xml
@@ -26,6 +26,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://subramanya.ai/assets/css/pages/loop-marketplace.css</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://subramanya.ai/assets/css/pages/search.css</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
@@ -537,6 +542,11 @@
   </url>
   <url>
     <loc>https://subramanya.ai/assets/js/pages/home.js</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://subramanya.ai/assets/js/pages/loop-marketplace.js</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -45,4 +45,11 @@ layout: null
       <priority>0.5</priority>
     </url>
   {% endfor %}
+  {% for loop in site.loops %}
+    <url>
+      <loc>{{ site.url }}{{ loop.url }}</loc>
+      <changefreq>weekly</changefreq>
+      <priority>0.5</priority>
+    </url>
+  {% endfor %}
 </urlset>


### PR DESCRIPTION
## Summary

Adds an automation loop marketplace at `/awesome-loops/automation/` backed by Markdown files in `_loops/`. Includes curated loop entries, optional submission metadata, export formats for Claude/Codex/Cursor, and repository review guardrails.

## Validation

- `node --check assets/js/pages/loop-marketplace.js`
- `ruby scripts/validate_content.rb`
- `JEKYLL_ENV=production RBENV_VERSION=3.3.3 bundle exec jekyll build`
- Browser QA for marketplace render, filtering, generated Markdown preview, breadcrumbs, and detail export panel

## Note

`htmlproofer` still reports a pre-existing unrelated broken books URL: `/navigating-umass-amherst-a-handbook-for-international-students`. Loop pages were not part of that failure list.